### PR TITLE
Version 0 GO Implementation

### DIFF
--- a/config/config.go.yaml
+++ b/config/config.go.yaml
@@ -6,7 +6,7 @@
 
 run:
   prefix: ""
-  name: "multi-year-it"
+  name: "v1-multi-year-it-10e-0h"
   scenarios:
     enable: false
     file: config/scenarios.yaml
@@ -28,9 +28,10 @@ scenario:
   sector_opts:
   - ''
   planning_horizons:
-  - 2025
+  - 2020
   - 2030
-  - 2035
+  - 2040
+  # - 2050 (Currently infeasable for IT)
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#countries
 countries: ['IT'] #['AL', 'AT', 'BA', 'BE', 'BG', 'CH', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'GR', 'HR', 'HU', 'IE', 'IT', 'LT', 'LU', 'LV', 'ME', 'MK', 'NL', 'NO', 'PL', 'PT', 'RO', 'RS', 'SE', 'SI', 'SK', 'XK']
@@ -49,14 +50,28 @@ enable:
   build_cutout: false
   retrieve_cutout: false
   drop_leap_day: true
-  certificate: true  # [true, false ] If true, model the guarantee of origin
+  certificate: true # [true, false ] If true, model the guarantee of origin
+
+clustering:
+  temporal:
+    resolution_sector: 3H
+
+sector:
+  methanol:
+    regional_methanol_demand: true
 
 certificate:
   scope: national # {national, global}
   plant_carriers: ["offwind", "offwind-ac", "offwind-dc", "offwind-float", "onwind", "ror", "hydro", "urban central solid biomass CHP", "geothermal", "solar", "solar-hsat", "solar rooftop", "nuclear"]
   plant_status: ["new", "existing"] # ["new", "existing"] if you include all (both new or existing), or only new powerplants
   max_plant_lifetime_as_new: 10
-  plant_grouping: ["country", "carrier", "status"]
+  plant_grouping: ["carrier", "status"] # [] or ["carrier", "status"]
+  bus_grouping: [] # [] or ["carrier", "status"]
 
-  strategy: vol-match
   energy_matching: 10 # in percent
+  hourly_matching: 0 #80 # in percent
+
+  map:
+    supply: [-0.5,-0.5]
+    demand: [0.5,0.5]
+    market: [0,0]

--- a/rules/solve_myopic.smk
+++ b/rules/solve_myopic.smk
@@ -120,6 +120,8 @@ rule add_certificate:
         network=resources(
             "networks/base_s_{clusters}_{opts}_{sector_opts}_{planning_horizons}_brownfield.nc"
         ),
+        country_shapes=resources("country_shapes.geojson"),
+        europe_shape=resources("europe_shape.geojson"),
     output:
         network=resources(
             "networks/base_s_{clusters}_{opts}_{sector_opts}_{planning_horizons}_certificate.nc"

--- a/scripts/add_certificate.py
+++ b/scripts/add_certificate.py
@@ -8,8 +8,10 @@ This script is part of a PyPSA-Eur workflow that adds Guarantee of Certificates 
 import logging
 
 import numpy as np
+import geopandas as gpd
 import pandas as pd
 import pypsa
+import warnings
 
 from scripts._helpers import (
     configure_logging,
@@ -20,17 +22,102 @@ from scripts._helpers import (
 logger = logging.getLogger(__name__)
 
 
+def get_largest_country_node(n, output_index=None):
+    df = pd.DataFrame(n.snapshot_weightings.objective @ n.loads_t.p_set)
+    df["country"] = df.index.map(n.buses.country)
+
+    df = df.dropna(subset=["country"])
+    max_indices = df.groupby("country")["objective"].idxmax()
+    df = df.loc[max_indices]
+
+    df["x"] = df.index.map(n.buses.x)
+    df["y"] = df.index.map(n.buses.y)
+
+    if isinstance(output_index, str):
+        df["new_index"] = [output_index + " " + c for c in df.country]
+        df = df.set_index("new_index")
+
+    return df
+
+
+def get_geo_center(shapes, output_index=None, x_offset=0, y_offset=0):
+
+    gdf = gpd.read_file(shapes)
+
+    # Rename 'name' column to 'country' if it exists
+    if "name" in gdf.columns:
+        gdf = gdf.rename(columns={"name": "country"})
+    else:
+        gdf["country"] = "EU"
+
+    # Suppress the warning about geographic CRS
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Geometry is in a geographic CRS.*")
+        gdf["center"] = gdf.centroid
+
+    # Extract lon/lat
+    gdf["x"] = gdf["center"].x + x_offset  # Longitude
+    gdf["y"] = gdf["center"].y + y_offset  # Latitude
+
+    # Handle output index
+    if isinstance(output_index, str):
+        gdf["new_index"] = [output_index + " " + c for c in gdf["country"]]
+        gdf = gdf.set_index("new_index")
+    else:
+        gdf = gdf.set_index("country", drop=False)
+
+    return gdf
+
+
+def add_virtual_carriers(n, carriers):
+    virtual_carrier_dict = {c: f"virtual {c}" for c in carriers}
+    new_carriers = [
+        orig
+        for orig, virt in virtual_carrier_dict.items()
+        if virt not in n.carriers.index
+    ]
+
+    if not new_carriers:
+        logger.info(
+            "No new virtual carriers added. All are already present in the network."
+        )
+        return
+
+    existing = n.carriers.loc[n.carriers.index.intersection(new_carriers)].copy()
+    missing = set(new_carriers) - set(existing.index)
+    if missing:
+        logger.warning(
+            f"The following carriers were requested but not found in the network and will be skipped:\n - {'\n - '.join(missing)}"
+        )
+
+    if existing.empty:
+        logger.warning("No valid carriers found to create virtual versions.")
+        return
+
+    virtual_carriers = existing.copy()
+    virtual_carriers.index = "virtual " + virtual_carriers.index
+    virtual_carriers["nice_name"] = "Virtual " + virtual_carriers["nice_name"]
+
+    n.add(
+        "Carrier",
+        virtual_carriers.index,
+        co2_emissions=0,
+        color=virtual_carriers.color,
+        nice_name=virtual_carriers.nice_name,
+    )
+
+    logger.info(
+        "Virtual carriers defined:\n - " + "\n - ".join(virtual_carriers.index.tolist())
+    )
+
+
 def get_virtual_ppl_dataframe(n, certificate, planning_horizons):
     carriers = certificate["plant_carriers"]
     status = certificate["plant_status"]
-    grouping = certificate["plant_grouping"].copy()
+    plant_group = certificate["plant_grouping"].copy()
+    bus_group = certificate["bus_grouping"]
     max_lifetime_as_new = certificate["max_plant_lifetime_as_new"]
     new_threshold = int(planning_horizons) - max_lifetime_as_new
-
-    grouping.append("component")
-
-    if certificate["scope"] == "national" and "country" not in grouping:
-        grouping.append("country")
 
     # Filtering out links with generator carriers (coal, oil, nuclear)
     shared_carriers = set(n.generators.carrier) & set(n.links.carrier)
@@ -64,33 +151,45 @@ def get_virtual_ppl_dataframe(n, certificate, planning_horizons):
         df = pd.concat([df, df_comp])
 
     df["ppl"] = df.index
-    df = pd.DataFrame(df.groupby(grouping)["ppl"].apply(list))
-    df["virtual_ppl"] = (
-        "virtual"
-        + (" " + df.index.get_level_values("country") if "country" in grouping else "")
-        + (" " + df.index.get_level_values("carrier") if "carrier" in grouping else "")
-        + (" " + df.index.get_level_values("status") if "status" in grouping else "")
+    plant_group.extend(["component", "country"])
+    df_vpp = pd.DataFrame(df.groupby(plant_group)["ppl"].apply(list))
+    df_vpp["virtual_ppl"] = (
+        "virtual "
+        + df_vpp.index.get_level_values("country")
+        + (" " + df_vpp.index.get_level_values("carrier") if "carrier" in plant_group else " " + df_vpp.index.get_level_values("component"))
+        + (" " + df_vpp.index.get_level_values("status") if "status" in plant_group else "")
     )
-    df = df.reset_index().set_index("virtual_ppl")
 
-    return df
+    
+    df_vpp["virtual_carrier"] = (
+        "virtual " + df_vpp.index.get_level_values("carrier") if "carrier" in plant_group else "GoO"
+    )
+
+    df_vpp["virtual_bus"] = (
+        "GO Supply "
+        + df_vpp.index.get_level_values("country")
+        + (" " + df_vpp.index.get_level_values("carrier") if "carrier" in bus_group else "")
+        + (" " + df_vpp.index.get_level_values("status") if "status" in bus_group else "")
+    )
+
+    df_vpp = df_vpp.reset_index().set_index("virtual_ppl")
+
+    return df_vpp
 
 
-def create_national_go_market(n):
-    df = pd.DataFrame(n.snapshot_weightings.objective @ n.loads_t.p_set)
-    df["country"] = df.index.map(n.buses.country)
+def add_virtual_ppl(n, certificate, planning_horizons):
+    df_vpp = get_virtual_ppl_dataframe(n, certificate, planning_horizons)
 
-    df = df.dropna(subset=["country"])
-    max_indices = df.groupby("country")["objective"].idxmax()
-    df = df.loc[max_indices]
-
-    df["x"] = df.index.map(n.buses.x)
-    df["y"] = df.index.map(n.buses.y)
-    df["bus"] = "GO Market " + df["country"]
-    df["demand"] = "GO Demand " + df["country"]
-
-    df_bus = df.set_index("bus")
-    df_demand = df.set_index("demand")
+    df_bus = df_vpp.groupby(["virtual_bus", "country"]).size().reset_index("country")
+    print(snakemake.input.country_shapes)
+    df_node = get_geo_center(
+        snakemake.input.country_shapes, 
+        x_offset=certificate["map"]["supply"][0], 
+        y_offset=certificate["map"]["supply"][1]
+    )
+    #df_node = get_largest_country_node(n).set_index("country")
+    df_bus["x"] = df_bus["country"].map(df_node.x)
+    df_bus["y"] = df_bus["country"].map(df_node.y)
 
     n.add(
         "Bus",
@@ -103,58 +202,130 @@ def create_national_go_market(n):
     )
 
     n.add(
-        "Store",
-        df_demand.index,
-        e_nom_extendable=True,
-        e_min_pu=-1,
-        carrier="GoO",
-        bus=df_demand["bus"],
+        "Generator",
+        df_vpp.index,
+        bus=df_vpp["virtual_bus"],
+        carrier=df_vpp["virtual_carrier"],
+        p_nom_extendable=True,
     )
 
-    logger.info(f"New Buses added:\n - {'\n - '.join(set(df_bus.index))}")
-    logger.info(f"New Stores added:\n - {'\n - '.join(set(df_demand.index))}")
+    logger.info(
+        "Virtual power plant buses added:\n - " + "\n - ".join(df_bus.index.tolist())
+    )
 
 
-# def add_virtual_carriers(n, carriers):
-#     virtual_carrier_dict = {c: f"virtual {c}" for c in carriers}
-#     new_carriers = [
-#         orig
-#         for orig, virt in virtual_carrier_dict.items()
-#         if virt not in n.carriers.index
-#     ]
+def add_virtual_demand(n, certificate):
+    energy_matching = certificate["energy_matching"] / 100
+    hourly_matching = certificate["hourly_matching"] / 100
+    df_demand = get_geo_center(
+        snakemake.input.country_shapes,
+        "GO Demand",
+        x_offset=certificate["map"]["demand"][0], 
+        y_offset=certificate["map"]["demand"][1]
+    )
+    # df_demand = get_largest_country_node(n, "GO Demand")
 
-#     if not new_carriers:
-#         logger.info(
-#             "No new virtual carriers added. All are already present in the network."
-#         )
-#         return
+    n.add(
+        "Bus",
+        df_demand.index,
+        carrier="GoO",
+        country=df_demand["country"],
+        location=df_demand["country"],
+        x=df_demand["x"],
+        y=df_demand["y"],
+    )
 
-#     existing = n.carriers.loc[n.carriers.index.intersection(new_carriers)].copy()
-#     missing = set(new_carriers) - set(existing.index)
-#     if missing:
-#         logger.warning(
-#             f"The following carriers were requested but not found in the network and will be skipped:\n - {'\n - '.join(missing)}"
-#         )
+    # This is the simplified version of GO profile
+    df_load = n.loads_t.p_set.copy()
+    go_list = n.buses.loc[df_demand.index, "location"]
+    go_list = pd.Series(go_list.index, index=go_list.values)
+    df_load.columns = df_load.columns.map(n.loads.bus).map(n.buses.country).map(go_list)
+    df_load = df_load.T.groupby(df_load.columns).sum().T
 
-#     if existing.empty:
-#         logger.warning("No valid carriers found to create virtual versions.")
-#         return
+    df_load *= energy_matching
 
-#     virtual_carriers = existing.copy()
-#     virtual_carriers.index = "virtual " + virtual_carriers.index
-#     virtual_carriers["nice_name"] = "Virtual " + virtual_carriers["nice_name"]
+    n.add(
+        "Load",
+        df_load.columns,
+        p_set=df_load,
+        carrier="GoO",
+        bus=df_load.columns,
+    )
 
-#     n.add(
-#         "Carrier",
-#         virtual_carriers.index,
-#         co2_emissions=0,
-#         color=virtual_carriers.color,
-#         nice_name=virtual_carriers.nice_name,
-#     )
+    logger.info("GO Demand added:\n - " + "\n - ".join(df_load.columns.tolist()))
 
-#     logger.info(
-#         "Virtual carriers defined:\n - " + "\n - ".join(virtual_carriers.index.tolist())
-#     )
+    # 247-go is defined as hourly_matching = 100%, where vol-match is defined as hourly_matching = 0%
+    if hourly_matching != 1:
+        df_buffer = pd.DataFrame(n.snapshot_weightings.objective @ df_load)
+        df_buffer["e_nom"] = df_buffer["objective"] * (1 - hourly_matching)
+        df_buffer["bus"] = df_buffer.index
+        df_buffer.rename(index=lambda i: i.replace("Demand", "Buffer"), inplace=True)
+
+        n.add(
+            "Store",
+            df_buffer.index,
+            bus=df_buffer["bus"],
+            carrier="GoO",
+            e_nom=df_buffer["e_nom"],
+            e_min_pu=-1,
+            e_cyclic=True,
+        )
+
+        logger.info(
+            f"GO Buffer added proportion to {(1 - hourly_matching) * 100}% of GO demand"
+        )
+
+
+def add_go_market(n, certificate):
+    scope = certificate["scope"]
+    # Filter all GO Supply and GO Demand buses
+    df_link = n.buses[n.buses.index.str.contains("GO Supply|GO Demand")][
+        ["carrier", "country"]
+    ].copy()
+
+    # Assign bus0 and bus1 based on the type
+    if scope == "national":
+        shape = snakemake.input.country_shapes
+        df_link["market_bus"] = ["GO Market " + c for c in df_link.country]
+    else:
+        shape = snakemake.input.europe_shape
+        df_link["market_bus"] = "GO Market EU"
+    
+    df_market = get_geo_center(
+        shape,
+        "GO Market",
+        x_offset=certificate["map"]["market"][0], 
+        y_offset=certificate["map"]["market"][1]
+    )
+
+    n.add(
+        "Bus",
+        df_market.index,
+        carrier="GoO",
+        country=df_market["country"],
+        location=df_market["country"],
+        x=df_market["x"],
+        y=df_market["y"],
+    )
+
+    logger.info("GO Market added:\n - " + "\n - ".join(df_market.index.tolist()))
+
+    df_link["bus0"] = df_link.index.where(
+        df_link.index.str.contains("GO Supply"), df_link["market_bus"]
+    )
+    df_link["bus1"] = df_link.index.where(
+        df_link.index.str.contains("GO Demand"), df_link["market_bus"]
+    )
+
+    n.add(
+        "Link",
+        df_link.index,
+        bus0=df_link["bus0"],
+        bus1=df_link["bus1"],
+        carrier="GoO",
+        p_nom_extendable=True,
+        reversed=False,
+    )
 
 
 if __name__ == "__main__":
@@ -180,8 +351,6 @@ if __name__ == "__main__":
     certificate = snakemake.params.certificate
     planning_horizons = snakemake.wildcards.get("planning_horizons", None)
 
-    vpp = get_virtual_ppl_dataframe(n, certificate, planning_horizons)
-
     # Add Certificates
     n.add(
         "Carrier",
@@ -190,40 +359,17 @@ if __name__ == "__main__":
         color="#98c41c",
         nice_name="Guarantee of Origin",
     )
+    if "carrier" in certificate["plant_grouping"]:
+        carriers = certificate["plant_carriers"]
+        add_virtual_carriers(n, carriers)
 
-    # Add GO Market(s) and Demand
-    if certificate["scope"] == "national":
-        vpp["virtual_bus"] = ["GO Market " + country for country in vpp.country]
-        create_national_go_market(n)
-    else:
-        vpp["virtual_bus"] = ["GO Market"]
+    # Add national supply bus
+    add_virtual_ppl(n, certificate, planning_horizons)
 
-        n.add(
-            "Bus",
-            "GO Market",
-            carrier="GoO",
-            country="EU",
-            location="EU",
-            x=n.buses.loc["EU", "x"],
-            y=n.buses.loc["EU", "y"],
-        )
+    # Add national demand bus
+    add_virtual_demand(n, certificate)
 
-        n.add(
-            "Store",
-            "GO Demand",
-            e_nom_extendable=True,
-            e_min_pu=-1,
-            carrier="GoO",
-            bus="GO Market",
-        )
-
-    # Add Virtual Power Plants
-    n.add(
-        "Generator",
-        vpp.index,
-        bus=vpp["virtual_bus"],
-        carrier="GoO",
-        p_nom_extendable=True,
-    )
+    # Add GO Market as an intermediary
+    add_go_market(n, certificate)
 
     n.export_to_netcdf(snakemake.output[0])

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1210,35 +1210,65 @@ def add_virtual_ppl_matching(n):
     logger.info("Activate: add_virtual_ppl_matching")
 
 
-def add_go_annual_matching_constraints(n, snapshots):
-    certificate = n.config["certificate"]
-    weights = n.snapshot_weightings["stores"]
-    energy_matching = certificate["energy_matching"] / 100
+# def add_go_annual_matching_constraints(n, snapshots):
+#     certificate = n.config["certificate"]
+#     weights = n.snapshot_weightings["stores"]
+#     energy_matching = certificate["energy_matching"] / 100
 
-    demand_list = n.stores.filter(like="GO Demand", axis=0).index
-    df = n.loads_t.p_set.copy()
+#     demand_list = n.stores.filter(like="GO Demand", axis=0).index
+#     df = n.loads_t.p_set.copy()
 
-    if certificate["scope"] == "national":
-        go_list = n.stores.loc[demand_list].bus.map(n.buses.location)
-        go_list = pd.Series(go_list.index, index=go_list.values)
-        df.columns = df.columns.map(n.loads.bus).map(n.buses.country).map(go_list)
-        df = df.T.groupby(df.columns).sum().T
-    else:
-        df["GO Demand"] = df.T.sum()
-        df = df[["GO Demand"]]
+#     if certificate["scope"] == "national":
+#         go_list = n.stores.loc[demand_list].bus.map(n.buses.location)
+#         go_list = pd.Series(go_list.index, index=go_list.values)
+#         df.columns = df.columns.map(n.loads.bus).map(n.buses.country).map(go_list)
+#         df = df.T.groupby(df.columns).sum().T
+#     else:
+#         df["GO Demand"] = df.T.sum()
+#         df = df[["GO Demand"]]
 
-    df.columns.name = "Store"
-    rhs = weights @ df
+#     df.columns.name = "Store"
+#     rhs = weights @ df
 
-    last_i = snapshots[-1]
-    lhs = n.model["Store-e"].loc[last_i, demand_list]
+#     last_i = snapshots[-1]
+#     lhs = n.model["Store-e"].loc[last_i, demand_list]
 
-    n.model.add_constraints(
-        lhs == energy_matching * rhs,
-        name="go_annual_matching_constraint",
-    )
+#     n.model.add_constraints(
+#         lhs == energy_matching * rhs,
+#         name="go_annual_matching_constraint",
+#     )
 
-    logger.info("Activate: add_go_annual_matching_constraints")
+#     logger.info("Activate: add_go_annual_matching_constraints")
+
+
+# def add_247_go_matching_constraints(n):
+#     certificate = n.config["certificate"]
+#     weights = n.snapshot_weightings["stores"]
+#     energy_matching = certificate["energy_matching"] / 100
+
+#     demand_list = n.stores.filter(like="GO Demand", axis=0).index
+#     df = n.loads_t.p_set.copy()
+
+#     if certificate["scope"] == "national":
+#         go_list = n.stores.loc[demand_list].bus.map(n.buses.location)
+#         go_list = pd.Series(go_list.index, index=go_list.values)
+#         df.columns = df.columns.map(n.loads.bus).map(n.buses.country).map(go_list)
+#         df = df.T.groupby(df.columns).sum().T
+#     else:
+#         df["GO Demand"] = df.T.sum()
+#         df = df[["GO Demand"]]
+
+#     df.columns.name = "Store"
+#     rhs = weights @ df
+
+#     lhs = n.model["Store-p"].loc[:, demand_list].sum(dim="snapshot")
+
+#     n.model.add_constraints(
+#         lhs == energy_matching * rhs,
+#         name="247_go_matching_constraint",
+#     )
+
+#     logger.info("Activate: add_247_go_matching_constraints")
 
 
 def extra_functionality(
@@ -1321,11 +1351,12 @@ def extra_functionality(
         custom_extra_functionality(n, snapshots, snakemake)  # pylint: disable=E0601
 
     if config["enable"].get("certificate"):
-        strategy = config["certificate"]["strategy"]
         add_virtual_ppl_matching(n)
 
-        if strategy == "vol-match":
-            add_go_annual_matching_constraints(n, snapshots)
+        # if strategy == "vol-match":
+        #     add_go_annual_matching_constraints(n, snapshots)
+        # if strategy == "247-go":
+        #     add_247_go_matching_constraints(n)
 
 
 def check_objective_value(n: pypsa.Network, solving: dict) -> None:


### PR DESCRIPTION
## Changes proposed in this Pull Request

This is the base configuration for the GO models, the naming schemes can still be discussed.
```yaml
enable:
  certificate: true

certificate:
  scope: national # {national, global}
  plant_carriers: ["offwind", "offwind-ac", "offwind-dc", "offwind-float", "onwind", "ror", "hydro", "urban central solid biomass CHP", "geothermal", "solar", "solar-hsat", "solar rooftop", "nuclear"]
  plant_status: ["new", "existing"] # ["new", "existing"] if you include all (both new or existing), or only new powerplants
  max_plant_lifetime_as_new: 10
  plant_grouping: ["carrier", "status"] # [] or ["carrier", "status"]
  bus_grouping: [] # [] or ["carrier", "status"]

  energy_matching: 10 # in percent
  hourly_matching: 0 #80 # in percent

  map:
    supply: [-0.5,-0.5]
    demand: [0.5,0.5]
    market: [0,0]
```

* `scope` is if you want the GO market to be on a national level or a global EU wide level
* `plant_carriers` is the plant that can participate in the GO scheme
* `plant status` is disaggregation based on the lifetime of the listed plant carriers (for targeted investment)
* `max_plant_lifetime_as_new` is the definition of new power plants, anything younger is defined as new. This is always updated every planning horizons
* `plant_grouping` is how granular is the virtual power plants is disaggregated. For national scope, country grouping will be added automatically

* (Not in use) `strategy` can either volume matching or 247-go
* `energy_matching` is the share of the load demand that procures this GO

## Checklist

- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.
- [ ] Changed dependencies are added to `envs/environment.yaml`.
- [ ] Changes in configuration options are added in `config/config.default.yaml`.
- [ ] Changes in configuration options are documented in `doc/configtables/*.csv`.
- [x] OET license identifier is added to all edited or newly created code files.
- [ ] Sources of newly added data are documented in `doc/data_sources.rst`.
- [ ] A release note `doc/release_notes.rst` is added.
