### PR TITLE
Bugfix: definition of 2nd constraint for modeling buffer GO generators

### DIFF
--- a/config/config.go.yaml
+++ b/config/config.go.yaml
@@ -9,8 +9,9 @@ run:
   name:
   #- baseline-3H
   #- baseline-co2-price-low-3H
-  - baseline-co2-price-medium-3H
+  #- baseline-co2-price-medium-3H
   #- baseline-co2-price-high-3H
+  - hourly-match-90-3H
   scenarios:
     enable: true
     file: config/scenarios.go-3H.yaml

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -1334,7 +1334,7 @@ def add_buffer_matching(n):
     )
 
     # 2nd Constraint: the buffer discharge must not exceed the hourly matching limit
-    lhs = weights * discharger
+    lhs = (weights * n.model["Generator-p"].loc[:, df[df.sign == 1].index]).sum(dim="snapshot")
     rhs = df.loc[df.sign == 1,"p_nom"]
 
     n.model.add_constraints(
@@ -1782,7 +1782,7 @@ if __name__ == "__main__":
 
         snakemake = mock_snakemake(
             "solve_sector_network_myopic",
-            run="baseline-3H",
+            run="hourly-match-90-3H",
             opts="",
             clusters="39",
             configfiles="config/config.go.yaml",


### PR DESCRIPTION
Closes #14.

## Changes proposed in this Pull Request
This PR includes the correction of what I consider a wrong implementation of `buffer_matching_constraints` in `add_buffer_matching`.

In particolar, the current definition of the `lhs` implies both the `Generator` and `snapshot` as dimensions, whereas it should only include the `Generator` one. More details on the bug and the bugfix are described in #14.

## Checklist
- [x] I tested my contribution locally and it works as intended.
- [x] Code and workflow changes are sufficiently documented.